### PR TITLE
Update MIstack.py

### DIFF
--- a/DSH/MIstack.py
+++ b/DSH/MIstack.py
@@ -141,7 +141,7 @@ class MIstack():
             return None
     def Count(self):
         return len(self.MIfiles)    
-    def GetMetaData(self, section=None):
+    def GetMetadata(self, section=None):
         assert isinstance(self.MetaData, cf.Config), 'MetaData not loaded yet: ' + str(self.MetaData)
         return self.MetaData.ToDict(section=section)
     def ImageShape(self):


### PR DESCRIPTION
I changed def GetMetaData into GetMetadata due to this error 

AttributeError: 'MIstack' object has no attribute 'GetMetadata'

that I encountered while i was performing the correlation data with a MIstack object:

corrmap = CM.CorrMaps(mi_stack, froot, [1], KernelSpecs, imgRange=im_range, cropROI=test_ROI)
cmap_list = corrmap.Compute(silent=False, return_maps=True) 

with this changment it worked